### PR TITLE
NAS-109587 / 12.0 / Normalize jail root attribute in fstab

### DIFF
--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -203,7 +203,7 @@ class IOCFstab(object):
         # `actions` specify on which `action` to raise validation error
         dests = OrderedDict()
         verrors = []
-        jail_root = f'{self.iocroot}/jails/{self.uuid}/root'
+        jail_root = self.__fstab_encode__(f'{self.iocroot}/jails/{self.uuid}/root')
 
         for index, line in enumerate(fstab):
             # Comment


### PR DESCRIPTION
This commit introduces changes to normalize jail root if it has special characters like spaces so that we make an equal/valid comparison with values

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
