### PR TITLE
NAS-109778 / 12.0 / Don't fail at deleting misconfigured jail

### DIFF
--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -270,10 +270,10 @@ class IOCDestroy:
 
         try:
             iocage_lib.ioc_stop.IOCStop(uuid, path, silent=True)
-        except (FileNotFoundError, RuntimeError, SystemExit):
+        except (FileNotFoundError, RuntimeError, SystemExit, iocage_lib.ioc_exceptions.JailMissingConfiguration):
             # Broad exception as we don't care why this failed. iocage
             # may have been killed before configuration could be made,
-            # it's meant to be nuked.
+            # it's meant to be nuked or is a malformed jail which does not has it's configuration file present
             pass
 
         try:


### PR DESCRIPTION
This commit fixes an issue where we do not fail at deleting a misconfigured jail which does not has it's configuration file present.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
