### PR TITLE
NAS-110691 / 12.0 / fix HUGE memory allocation on middlewared startup

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -164,8 +164,8 @@ class IOCPlugin(object):
                         raise FileNotFoundError(f'{packagesite_path} not found')
 
                     with open(packagesite_path, 'r') as f:
-                        for line in f.read().split('\n'):
-                            searched = RE_PLUGIN_VERSION.findall(line)
+                        for line in f:
+                            searched = RE_PLUGIN_VERSION.findall(line.strip('\r\n'))
                             if not searched:
                                 continue
                             name = searched[0].rsplit('/', 1)[-1]


### PR DESCRIPTION
I'm tracking a memory leak in `middlewared` service. I've written a method to use the `tracemalloc` module to track allocated memory. Immediately I noticed that we're using 160MB+ memory on `middlewared` startup and it's because we're loading the yaml file entirely into memory "`read()`" (as 1 big string) and then iterating over every line "`strip('\n')`".

Furthermore, this file is already stored on `tmpfs` which is using memory already so we're potentially using 2-3x the memory unnecessarily.

My change is simple, don't load the file into RAM (since it's already there on tmpfs), simply iterate over the file itself.

Before the change:
`[2021/05/18 05:27:59] (DEBUG) middlewared._tracemalloc_start():1412 - #1: /usr/local/lib/python3.9/site-packages/iocage_lib/ioc_plugin.py:167: size=163 MiB (+163 MiB), count=2 (+2), average=81.4 MiB`

After the change:
- it's no longer reported by the `tracemalloc` module 😄 
