### PR TITLE
NAS-111775 / 12.0 / Update version matching regex for plugins

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -59,7 +59,7 @@ from iocage_lib.dataset import Dataset
 
 
 GIT_LOCK = threading.Lock()
-RE_PLUGIN_VERSION = re.compile(r'"path":"([/\.\+,\d\w-]*)\.txz"')
+RE_PLUGIN_VERSION = re.compile(r'"path"\s*:\s*"([/\.\+,\d\w-]*)\.(?:\btxz\b|\bpkg\b)"')
 
 
 class IOCPlugin(object):


### PR DESCRIPTION
This commit adds changes to adapt regext to accept new format specified by upstream freebsd pkg but still support the old one as it's being used by us for packagesites which are hosted by us.

