### PR TITLE
NAS-113392 / 12.0 / fix all_properties() stripping whitespace

### DIFF
--- a/iocage_lib/zfs.py
+++ b/iocage_lib/zfs.py
@@ -75,7 +75,7 @@ def all_properties(
     fs = defaultdict(dict)
     for line in filter(bool, data):
         name, prop = line.split('\t')[:2]
-        fs[name.strip()][prop.strip()] = line.split(
+        fs[name][prop.strip()] = line.split(
             '\t', maxsplit=2
         )[-1].strip()
 


### PR DESCRIPTION
ZFS allows trailing whitespace for zpool names. A horrible decision, in my opinion, but the fact remains it's allowed. Mostly we see this happen by accident. When this occurs, iocage explodes because it strips the trailing whitespace in the `all_properties()` function which essentially breaks everything. This fixes it to not `strip()` whitespace from the zpool name.
