### PR TITLE
NAS-113813 / 12.0 / Update plugin artifact before executing pre update script

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1304,6 +1304,17 @@ fingerprint: {fingerprint}
         iocage_lib.ioc_common.check_release_newer(
             plugin_release, self.callback, self.silent, major_only=True)
 
+        if plugin_conf['artifact']:
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'INFO',
+                    'message': 'Updating plugin artifact... '
+                },
+                _callback=self.callback,
+                silent=self.silent
+            )
+            self.__update_pull_plugin_artifact__(plugin_conf)
+
         # We want the new json to live with the jail
         plugin_name = self.plugin.rsplit('_', 1)[0]
         shutil.copy(


### PR DESCRIPTION
This commit adds changes to upgrade implementation of plugin to make sure we update plugin artifact before trying to upgrade. Motivation behind this change is that we are going to try to execute pre update hook but without updating the artifact from upstream, we won't have the latest changes upstream wanted resulting in a potential inconsistent upgrade.


