### PR TITLE
NAS-113823 / 12.0 / Make plugin jail a base jail if it's not already a basejail

### DIFF
--- a/iocage_lib/create_utils.py
+++ b/iocage_lib/create_utils.py
@@ -1,5 +1,5 @@
 import os
-import shutil
+import subprocess
 
 import iocage_lib.ioc_fstab
 
@@ -22,7 +22,8 @@ def strip_jail_for_base_jail(config: dict, release: str, iocroot: str, jail_uuid
         destination = os.path.join(iocroot, 'jails', jail_uuid, 'root', base_dir)
 
         # This reduces the REFER of the basejail.
-        shutil.rmtree(destination, ignore_errors=True)
+        # Just much faster by almost a factor of 2 than the builtins.
+        subprocess.Popen(['rm', '-r', '-f', destination]).communicate()
         os.mkdir(destination)
 
         iocage_lib.ioc_fstab.IOCFstab(jail_uuid, 'add', source, destination, 'nullfs', 'ro', '0', '0', silent=True)

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -55,6 +55,7 @@ import iocage_lib.ioc_exceptions
 import texttable
 
 from iocage_lib.cache import cache
+from iocage_lib.create_utils import strip_jail_for_base_jail
 from iocage_lib.dataset import Dataset
 
 
@@ -1348,6 +1349,12 @@ fingerprint: {fingerprint}
             },
             _callback=self.callback,
             silent=self.silent)
+
+        ioc_json_obj = iocage_lib.ioc_json.IOCJson(os.path.join(self.iocroot, 'jails', self.jail), silent=True)
+        config = ioc_json_obj.json_get_value('all')
+        if not config['basejail']:
+            config = strip_jail_for_base_jail(config, plugin_conf['release'], self.iocroot, self.jail)
+            ioc_json_obj.json_write(config)
 
         new_release = iocage_lib.ioc_upgrade.IOCUpgrade(
             plugin_release, path, silent=True


### PR DESCRIPTION
This PR adds changes for plugin jails to convert them to basejails when the plugin is upgraded if it's not already a basejail. This case wouldn't ideally happen unless for some users who are running our migrated version of asigra plugin where the jail is not a basejail.