### PR TITLE
NAS-113492 / 22.02 / Add readable message on connection error

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -31,6 +31,7 @@ import tarfile
 import tempfile
 import time
 import urllib.request
+import urllib3
 
 import requests
 import requests.auth
@@ -710,40 +711,52 @@ class IOCFetch:
                     dl_progress = 0
                     last_progress = 0
 
-                    for i, chunk in enumerate(
-                        r.iter_content(chunk_size=chunk_size), 1
-                    ):
-                        if chunk:
-                            elapsed = time.time() - start
-                            dl_progress += len(chunk)
-                            txz.write(chunk)
+                    try:
+                        for i, chunk in enumerate(
+                            r.iter_content(chunk_size=chunk_size), 1
+                        ):
+                            if chunk:
+                                elapsed = time.time() - start
+                                dl_progress += len(chunk)
+                                txz.write(chunk)
 
-                            progress = float(i) / float(total)
-                            if progress >= 1.:
-                                progress = 1
-                            progress = round(progress * 100, 0)
+                                progress = float(i) / float(total)
+                                if progress >= 1.:
+                                    progress = 1
+                                progress = round(progress * 100, 0)
 
-                            if progress != last_progress:
-                                text = self.update_progress(
-                                    progress,
-                                    f'Downloading: {f}',
-                                    elapsed,
-                                    chunk_size
-                                )
+                                if progress != last_progress:
+                                    text = self.update_progress(
+                                        progress,
+                                        f'Downloading: {f}',
+                                        elapsed,
+                                        chunk_size
+                                    )
 
-                                if progress % 10 == 0:
-                                    # Not for user output, but for callback
-                                    # heartbeats
-                                    iocage_lib.ioc_common.logit(
-                                        {
-                                            'level': 'INFO',
-                                            'message': text.rstrip()
-                                        },
-                                        _callback=self.callback,
-                                        silent=True)
+                                    if progress % 10 == 0:
+                                        # Not for user output, but for callback
+                                        # heartbeats
+                                        iocage_lib.ioc_common.logit(
+                                            {
+                                                'level': 'INFO',
+                                                'message': text.rstrip()
+                                            },
+                                            _callback=self.callback,
+                                            silent=True)
 
-                            last_progress = progress
-                            start = time.time()
+                                last_progress = progress
+                                start = time.time()
+                    except requests.exceptions.ChunkedEncodingError as exc:
+                        if isinstance(exc.__cause__, urllib3.exceptions.ProtocolError):
+                            iocage_lib.ioc_common.logit(
+                                {
+                                    "level": "EXCEPTION",
+                                    "message": f"Please check your internet connection. Error: {exc.__cause__}",
+                                },
+                                _callback=self.callback
+                            )
+                        else:
+                            raise
 
     def update_progress(self, progress, display_text, elapsed, chunk_size):
         """

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -31,7 +31,6 @@ import tarfile
 import tempfile
 import time
 import urllib.request
-import urllib3
 
 import requests
 import requests.auth
@@ -747,16 +746,13 @@ class IOCFetch:
                                 last_progress = progress
                                 start = time.time()
                     except requests.exceptions.ChunkedEncodingError as exc:
-                        if isinstance(exc.__cause__, urllib3.exceptions.ProtocolError):
-                            iocage_lib.ioc_common.logit(
-                                {
-                                    "level": "EXCEPTION",
-                                    "message": f"Please check your internet connection. Error: {exc.__cause__}",
-                                },
-                                _callback=self.callback
-                            )
-                        else:
-                            raise
+                        iocage_lib.ioc_common.logit(
+                            {
+                                "level": "EXCEPTION",
+                                "message": f"Please check your internet connection. Details: {exc}",
+                            },
+                            _callback=self.callback
+                        )
 
     def update_progress(self, progress, display_text, elapsed, chunk_size):
         """


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Catch ConnectionError to provide somewhat readable feedback to end user:
```python
# Exception chain:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/urllib3/contrib/pyopenssl.py", line 313, in recv_into
    return self.connection.recv_into(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/OpenSSL/SSL.py", line 1822, in recv_into
    self._raise_ssl_error(self._ssl, result)
  File "/usr/local/lib/python3.9/site-packages/OpenSSL/SSL.py", line 1639, in _raise_ssl_error
    raise SysCallError(errno, errorcode.get(errno))
OpenSSL.SSL.SysCallError: (54, 'ECONNRESET')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/urllib3/response.py", line 425, in _error_catcher
    yield
  File "/usr/local/lib/python3.9/site-packages/urllib3/response.py", line 507, in read
    data = self._fp.read(amt) if not fp_closed else b""
  File "/usr/local/lib/python3.9/http/client.py", line 462, in read
    n = self.readinto(b)
  File "/usr/local/lib/python3.9/http/client.py", line 506, in readinto
    n = self.fp.readinto(b)
  File "/usr/local/lib/python3.9/socket.py", line 704, in readinto
    return self._sock.recv_into(b)
  File "/usr/local/lib/python3.9/site-packages/urllib3/contrib/pyopenssl.py", line 318, in recv_into
    raise SocketError(str(e))
OSError: (54, 'ECONNRESET')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/requests/models.py", line 750, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File "/usr/local/lib/python3.9/site-packages/urllib3/response.py", line 564, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "/usr/local/lib/python3.9/site-packages/urllib3/response.py", line 529, in read
    raise IncompleteRead(self._fp_bytes_read, self.length_remaining)
  File "/usr/local/lib/python3.9/contextlib.py", line 137, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.9/site-packages/urllib3/response.py", line 443, in _error_catcher
    raise ProtocolError("Connection broken: %r" % e, e)
urllib3.exceptions.ProtocolError: ('Connection broken: OSError("(54, \'ECONNRESET\')")', OSError("(54, 'ECONNRESET')"))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/middlewared/job.py", line 367, in run
    await self.future
  File "/usr/local/lib/python3.9/site-packages/middlewared/job.py", line 405, in __run_body
    rv = await self.middleware.run_in_thread(self.method, *([self] + args))
  File "/usr/local/lib/python3.9/site-packages/middlewared/utils/run_in_thread.py", line 10, in run_in_thread
    return await self.loop.run_in_executor(self.run_in_thread_executor, functools.partial(method, *args, **kwargs))
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.9/site-packages/middlewared/schema.py", line 979, in nf
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/middlewared/plugins/jail_freebsd.py", line 296, in do_create
    ioc.IOCage(callback=progress_callback, silent=False).fetch(**{
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/iocage.py", line 1072, in fetch
    plugin_obj.fetch_plugin(props, 0, accept)
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_plugin.py", line 313, in fetch_plugin
    props, pkg = self.__fetch_plugin_props__(conf, props, num)
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_plugin.py", line 491, in __fetch_plugin_props__
    self.__fetch_release__(self.release)
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_plugin.py", line 1528, in __fetch_release__
    iocage_lib.iocage.IOCage(silent=self.silent).fetch(**fetch_args)
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/iocage.py", line 1105, in fetch
    ioc_fetch.IOCFetch(
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_fetch.py", line 215, in fetch_release
    rel = self.fetch_http_release(eol, _list=_list)
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_fetch.py", line 467, in fetch_http_release
    self.fetch_download(missing_files, missing=bool(missing_files))
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_fetch.py", line 713, in fetch_download
    for i, chunk in enumerate(
  File "/usr/local/lib/python3.9/site-packages/requests/models.py", line 753, in generate
    raise ChunkedEncodingError(e)
requests.exceptions.ChunkedEncodingError: ('Connection broken: OSError("(54, \'ECONNRESET\')")', OSError("(54, 'ECONNRESET')"))
```